### PR TITLE
Switches spelling of behavior to preferred American English variation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -18,7 +18,7 @@ assignees: ''
 
 [NOTE]: # ( Please be as specific as possible. )
 
-## Expected Behaviour
+## Expected Behavior
 
 [NOTE]: # ( Tell us what you expected to happen. )
 

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -13,7 +13,7 @@ assignees: ''
 
 [NOTE]: # ( Provide a brief overview of what the new feature is all about. )
 
-## Desired Behaviour
+## Desired Behavior
 
 [NOTE]: # ( Tell us how the new feature should work. Be specific. )
 [TIP]:  # ( Do NOT give us access or passwords to your New Relic account or API keys! )

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,4 +27,4 @@ For more information about CLAs, please check out Alex Russell’s excellent pos
 
 ## Slack
 
-For contributors and maintainers of open source projects hosted by New Relic, we host a public Slack with a channel dedicated to this project. If you are contributing to this project, you're welcome to request access to that  community space.
+For contributors and maintainers of open source projects hosted by New Relic, we host a public Slack with a channel dedicated to this project. If you are contributing to this project, you're welcome to request access to that community space.

--- a/javascript/oss-template/CONTRIBUTING.md
+++ b/javascript/oss-template/CONTRIBUTING.md
@@ -27,4 +27,4 @@ For more information about CLAs, please check out Alex Russell’s excellent pos
 
 ## Slack
 
-For contributors and maintainers of open source projects hosted by New Relic, we host a public Slack with a channel dedicated to this project. If you are contributing to this project, you're welcome to request access to that  community space.
+For contributors and maintainers of open source projects hosted by New Relic, we host a public Slack with a channel dedicated to this project. If you are contributing to this project, you're welcome to request access to that community space.


### PR DESCRIPTION
* Switches spelling of behavior to preferred American English spelling.
* Removes extra spaces from contributing docs.

We may have chosen this spelling on purpose, given global touch, but I don't typically see that variation of spelling used at NR. Figured I'd submit a PR for consistency, in case this was an oversight. Feel free to close out if not preferred.